### PR TITLE
Add --func and --level to which-queries-trigger-oohj script

### DIFF
--- a/bin/which-queries-trigger-oohj.rb
+++ b/bin/which-queries-trigger-oohj.rb
@@ -10,12 +10,25 @@ require_relative '../lib/mysql'
 CONFIG = YAML.load_file('config.yaml')['mysql']
 CLIENT = MySQL::Client.new(CONFIG['user'], CONFIG['port'], CONFIG['host'], CONFIG['name'], CONFIG['path'], silent=true)
 
+def create_hints(options)
+  if options[:func]
+    if options[:func] == 'DISABLED'
+      return ' /*+ DISABLE_OPTIMISTIC_HASH_JOIN */'
+    else
+      return " /*+ SET_OPTIMISM_FUNC(#{options[:func]}) SET_OPTIMISM_LEVEL(#{options[:level]})*/"
+    end
+  end
+  ''
+end
+
 # Count join occurrences in SQL queries from the job-queries directory
-def count_joins
+def count_optimistic(options)
+  hints = create_hints(options)
+
   files_with_optimistic = []
   Dir['./job-order-queries/*.sql'].each do |file|
     query = File.read(file).lines.map(&:strip).join(' ')
-    stdout, _, _ = CLIENT.run_query_get_stdout("EXPLAIN FORMAT=tree #{query}")
+    stdout, _stderr = CLIENT.run_query_get_stdout("EXPLAIN FORMAT=tree #{hints} #{query}")
     join_count = stdout.scan(/optimistic/i).size
     if join_count > 0
       files_with_optimistic << file
@@ -24,14 +37,44 @@ def count_joins
   return files_with_optimistic.sort
 end
 
-def run
-  files_with_optimistic = count_joins
-  File.open('./results/oohj-queries.txt', 'w') do |f|
+def output_file_name(options)
+  postfix = ''
+  if options[:func]
+    if options[:func] == 'DISABLED'
+      postfix = '-disabled'
+    elsif options[:func] != ''
+      postfix = "-#{options[:func]}-#{options[:level].to_s.gsub('.', '_')}"
+    end
+  end
+  "oohj-queries#{postfix}.txt"
+end
+
+def run(options)
+  files_with_optimistic = count_optimistic(options)
+  file_name = output_file_name(options)
+  file_path = "./results/#{file_name}"
+  File.open(file_path, 'w') do |f|
     files_with_optimistic.each do |file|
       f.puts File.basename(file, '.*')
     end
   end
-  puts "Successfully written to ./results/oohj-queries.txt"
+  puts "Successfully written to #{file_path}"
 end
 
-run if __FILE__ == $PROGRAM_NAME
+options = {}
+OptionParser.new do |opts|
+  opts.on('--func FUNCTION', 'Specify function to run') do |f|
+    options[:func] = f
+  end
+  opts.on('--level LEVEL', Float, 'Specify optimism level.') do |l|
+    options[:level] = l
+  end
+end.parse!
+
+if options[:func] && options[:func] != 'DISABLED' && !options[:level]
+  abort('If --func is specified and not equalt to DISABLED, --level must be specified')
+end
+
+puts(options)
+
+run(options) if __FILE__ == $PROGRAM_NAME


### PR DESCRIPTION
This commit introduces new command line arguments to enhance the functionality of the `which-queries-trigger-oohj.rb` script. The changes allow users to specify different functions and levels which will append suitable hints to the queries and for generating output files with particular naming conventions based on user input.

- Added command line arguments `--func` and `--level`.
- Implemented conditional logic for output file naming based on the provided function.
- Implemented conditional logic for adding hints to queries.

The main functionalities based on the `--func` argument are now available:

1. **Using a Function with Specified Level**
   If the `func` argument is provided and is not `DISABLED`, the `level` argument must also be provided. The output file will be named with the pattern: 
   ```
   output-<FUNCTION>-<LEVEL>.txt
   ```
   **Example:**
   ```bash
   $ ruby bin/which-queries-trigger-oohj.rb --func LINEAR --level 0.5
   ```
   This generates an output file named `output-LINEAR-0_5.txt`.

2. **Using the DISABLED Function**
   If `func` is set to `DISABLED`, the output file will be suffixed with `-disabled`, following the pattern:
   ```
   output-disabled.txt
   ```
   **Example:**
   ```bash
   $ ruby bin/which-queries-trigger-oohj.rb --func DISABLED
   ```

- If `func` is specified without a corresponding `level` (when `func` is not `DISABLED`), an error will be raised, ensuring users are aware of the requirement.

**Example of Possible Error:**
```bash
$ ruby bin/which-queries-trigger-oohj.rb --func LINEAR
```
This will raise an error or warning indicating that the `level` parameter is required.