### PR TITLE
Add count-ohj.rb for tracking optimistic hash join usage

### DIFF
--- a/README.org
+++ b/README.org
@@ -349,3 +349,17 @@ make homemade-feed
 #+begin_src shell
 make run-file DATABASE=homemade FILE=./sql/analyze_homemade.sql
 #+end_src
+
+** Count Optimistic Hash Join
+
+`bin/count-ohj.rb`, counts occurrences of "optimistic hash join" in SQL execution plans. It works by:
+
+#+begin_src sh
+ruby bin/count-ohj.rb [--join-buffer-size SIZE]
+#+end_src
+
+Example (setting join buffer size to 16MB):
+
+#+begin_src sh
+ruby bin/count-ohj.rb --join-buffer-size 16777216
+#+end_src

--- a/bin/count-ohj.rb
+++ b/bin/count-ohj.rb
@@ -1,0 +1,81 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'yaml'
+require 'terminal-table'
+require 'csv'
+require 'fileutils'
+
+require_relative '../lib/mysql'
+
+# Load MySQL configuration
+CONFIG = YAML.load_file('config.yaml')['mysql']
+CLIENT = MySQL::Client.new(CONFIG['user'], CONFIG['port'], CONFIG['host'], CONFIG['name'], CONFIG['path'], true)
+
+ALWAYS_PROPOSE_HINT = '/*+ SET_OPTIMISM_FUNC(SIGMOID) */'
+
+def parse_options
+  options = {}
+  OptionParser.new do |opts|
+    opts.banner = "Usage: #{$PROGRAM_NAME} [options]"
+    opts.on("--join-buffer-size SIZE", "Set join buffer size (in bytes)") do |size|
+      options[:join_buffer_size] = size
+    end
+  end.parse!
+  options
+end
+
+def count_optimistic
+  mapping = {}
+  Dir['./job-order-queries/*.sql'].each do |file|
+    # Read the SQL file and collapse it into a single line
+    query = File.read(file).lines.map(&:strip).join(' ')
+    # Insert the hint right after the SELECT keyword
+    modified_query = query.sub(/select\s+/i, "SELECT #{ALWAYS_PROPOSE_HINT} ")
+    # Construct the EXPLAIN query with the modified query
+    explain_query = "EXPLAIN FORMAT=tree #{modified_query}"
+    stdout, _stderr = CLIENT.run_query_get_stdout(explain_query)
+    # Count the occurrences of "optimistic hash join" (case-insensitive)
+    join_count = stdout.scan(/optimistic hash join/i).size
+    # Extract the query name (without extension)
+    query_name = File.basename(file, '.sql')
+    mapping[query_name] = join_count
+  end
+  mapping
+end
+
+def run
+  options = parse_options
+
+  # If join-buffer-size option is provided, set it globally in MySQL
+  if options[:join_buffer_size]
+    buffer_size = options[:join_buffer_size].to_i
+    CLIENT.run_query_get_stdout("SET GLOBAL join_buffer_size = #{buffer_size}")
+  end
+
+  results = count_optimistic
+
+  # Ensure the results directory exists
+  output_dir = './results'
+  FileUtils.mkdir_p(output_dir) unless Dir.exist?(output_dir)
+
+  # Prepare CSV file path; add join buffer size to the file name if provided
+  file_name = if options[:join_buffer_size]
+                "ohj-count-inf-memory-#{options[:join_buffer_size]}.csv"
+              else
+                'ohj-count-inf-memory.csv'
+              end
+  file_path = File.join(output_dir, file_name)
+
+  # Write results to CSV
+  CSV.open(file_path, 'w') do |csv|
+    csv << ['Query Name', 'Optimistic Hash Join Count']
+    results.each do |query_name, count|
+      csv << [query_name, count]
+    end
+  end
+
+  puts "Successfully written to #{file_path}"
+end
+
+run if __FILE__ == $PROGRAM_NAME


### PR DESCRIPTION
This pull request introduces a new Ruby script, `bin/count-ohj.rb`, designed to analyze SQL execution plans for the occurrence of the "optimistic hash join". The script performs the following:

- Scans all SQL files in the `./job-order-queries` directory.
- Modifies each SQL query by inserting a hint (`/*+ SET_OPTIMISM_FUNC(SIGMOID) */`) immediately after the `SELECT` keyword.
- Executes an `EXPLAIN FORMAT=tree` query against the modified SQL.
- Counts the number of times "optimistic hash join" appears in the output.
- Output the results into a CSV file in the `./results` directory. If a join buffer size is provided via the `--join-buffer-size` option, the output file name reflects this configuration.
- Supports an optional flag (`--join-buffer-size SIZE`) to set the global join buffer size in MySQL before running the analysis.

Additionally, the README has been updated to include detailed instructions on using this script and an example that demonstrates how to set the join buffer size to 16MB.

This new functionality will help monitor and optimize query performance by providing insights into how frequently optimistic hash joins are used in our SQL execution plans.